### PR TITLE
Add clang-format CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,21 @@ add_subdirectory(third_party/catch2)
 # Enable testing
 enable_testing()
 
+# Clang-format target
+find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format)
+if(CLANG_FORMAT_EXECUTABLE)
+    file(GLOB_RECURSE ALL_SOURCE_FILES
+        ${CMAKE_SOURCE_DIR}/src/*.cpp
+        ${CMAKE_SOURCE_DIR}/src/*.hpp
+    )
+    add_custom_target(
+        format
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${ALL_SOURCE_FILES}
+        COMMENT "Running clang-format on all C++ source files"
+        VERBATIM
+    )
+else()
+    message(WARNING "clang-format not found. 'format' target will not be available.")
+endif()
+
 add_subdirectory(src)


### PR DESCRIPTION
## Summary

Adds a convenient CMake target for running clang-format on all C++ source files in the project.

### Features
- **New `format` target**: Run `cmake --build build --target format` to format all code
- **Automatic file discovery**: Uses `file(GLOB_RECURSE)` to find all `.cpp` and `.hpp` files in `src/`
- **In-place formatting**: Applies clang-format with `-i` flag to modify files directly
- **Graceful degradation**: Shows warning if clang-format is not installed but continues build

### Usage
```bash
# Format all C++ source files
cmake --build build --target format
```

### Implementation
- Uses CMake's `find_program()` to locate clang-format executable
- Creates custom target that runs on all source files in the `src` directory
- Excludes third-party code (only formats files in `src/`)
- Uses `VERBATIM` flag for proper command escaping

### Testing
✓ Tested successfully with clang-format on existing source files
✓ CMake configuration succeeds with and without clang-format installed
✓ Target runs without errors

This provides a standardized way to maintain consistent code formatting across the project, making it easier for contributors to follow the project's style guidelines mentioned in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)