### PR TITLE
Add clang-format configuration with Google C++ style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,48 @@
+---
+# Clang-format configuration for fast-containers
+# Based on Google C++ Style Guide
+
+BasedOnStyle: Google
+
+# Language-specific settings for C++
+Language: Cpp
+Standard: Latest
+
+# Indentation
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+AccessModifierOffset: -1
+NamespaceIndentation: None
+
+# Line length
+ColumnLimit: 80
+
+# Includes
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+
+# Braces
+BreakBeforeBraces: Attach
+
+# Pointer and reference alignment
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Template formatting
+AlwaysBreakTemplateDeclarations: Yes
+
+# Function declarations and calls
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortFunctionsOnASingleLine: Inline
+BinPackParameters: true
+
+# Control statements
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# Comments
+ReflowComments: true
+
+# Other
+MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
## Summary

Adds a `.clang-format` configuration file to enforce consistent code formatting across the project based on Google C++ Style Guide conventions.

### Configuration Details

**Base Style**: Google C++ Style Guide

**Key Settings**:
- **Indentation**: 2 spaces (no tabs)
- **Line Length**: 80 characters maximum
- **C++ Standard**: Latest (C++23)
- **Pointer Alignment**: Left-aligned (`int* ptr` not `int *ptr`)
- **Brace Style**: Attach (opening brace on same line)
- **Include Sorting**: Case-sensitive with automatic regrouping
- **Template Declarations**: Always break before template declarations
- **Access Modifiers**: Indented -1 from class level
- **Namespace Indentation**: None

### Integration

This configuration file works seamlessly with:
- The `format` CMake target (from PR #4)
- Command-line clang-format usage
- IDE integrations (VS Code, CLion, etc.)

### Usage

**Via CMake target**:
```bash
cmake --build build --target format
```

**Manually**:
```bash
clang-format -i src/**/*.cpp src/**/*.hpp
```

**Check formatting without modifying**:
```bash
clang-format -n --Werror src/**/*.cpp
```

### Benefits

- **Consistency**: All contributors will use the same formatting style
- **Automation**: Format code automatically before commits
- **Code Review**: Focus on logic, not style nitpicks
- **Standards Compliance**: Follows industry-standard Google C++ Style Guide
- **C++23 Support**: Configured for latest C++ standard matching project requirements

### Testing

✓ Verified clang-format recognizes and applies the configuration
✓ Tested on existing source files - produces clean, consistent output
✓ Compatible with clang-format version 19.1.7+

This complements the project's existing code conventions mentioned in `CLAUDE.md` by providing automated enforcement of formatting standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)