### PR TITLE
Document PR description update workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,31 @@ perf stat -e cycles,instructions,cache-references,cache-misses,branches \\
 # Cache miss rate = cache-misses / cache-references * 100
 ```
 
+## GitHub Workflow
+
+### Updating PR Descriptions
+**Problem**: `gh pr edit <num> --body` fails with GraphQL deprecation error (Projects classic)
+
+**Solution**: Use REST API directly
+```bash
+# Write description to file first
+cat > /tmp/pr_body.md <<'EOF'
+Your PR description here...
+EOF
+
+# Update PR using REST API
+gh api \
+  --method PATCH \
+  -H "Accept: application/vnd.github+json" \
+  repos/kressler/fast-containers/pulls/<PR_NUM> \
+  -F body="$(cat /tmp/pr_body.md)"
+```
+
+**Key points**:
+- `-F body=` handles multi-line text correctly
+- `$(cat file)` preserves formatting
+- Works when `gh pr edit` fails with GraphQL errors
+
 ## Common Pitfalls
 
 | Issue | Wrong | Correct |


### PR DESCRIPTION
## Summary
Documents the workaround for updating PR descriptions when `gh pr edit` fails with GraphQL Projects (classic) deprecation error.

## Changes

### Added "GitHub Workflow" Section
New section in CLAUDE.md after "Benchmark Best Practices" covering:

**Problem**: `gh pr edit <num> --body` fails with:
```
GraphQL: Projects (classic) is being deprecated...
```

**Solution**: Use GitHub REST API directly via `gh api`:
```bash
cat > /tmp/pr_body.md <<'EOF'
Your PR description here...
EOF

gh api \
  --method PATCH \
  -H "Accept: application/vnd.github+json" \
  repos/kressler/fast-containers/pulls/<PR_NUM> \
  -F body="$(cat /tmp/pr_body.md)"
```

**Key Benefits**:
- `-F body=` flag handles multi-line text correctly
- `$(cat file)` preserves formatting (newlines, code blocks, etc.)
- Bypasses GraphQL endpoint that has deprecation issues
- Uses stable REST API

## Testing

Successfully used this method to update PR #27 description after fixing transfer operations.

## Why This Matters

- GitHub CLI's `gh pr edit` command currently broken due to Projects classic deprecation
- This workaround will save time when updating PR descriptions
- Documents tribal knowledge for future reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
