### PR TITLE
Add AddressSanitizer (ASAN) build configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,24 @@ hooks/, install-hooks.sh
 |------------|---------|---------------|
 | Debug | `cmake -S . -B cmake-build-debug && cmake --build cmake-build-debug --parallel` | None |
 | Debug+AVX2 | `cmake -S . -B cmake-build-debug -DENABLE_AVX2=ON && cmake --build cmake-build-debug --parallel` | AVX2 |
+| Debug+ASAN | `cmake -S . -B cmake-build-asan -DENABLE_ASAN=ON && cmake --build cmake-build-asan --parallel` | -fsanitize=address, -fno-omit-frame-pointer, -g, -O1 |
 | Release (default) | `cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release && cmake --build cmake-build-release --parallel` | -O3, -mavx2, -mfma, -march=haswell, -ffast-math, -funroll-loops, -mtune=native |
 | Release (no AVX2) | `cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_AVX2=OFF && cmake --build cmake-build-release --parallel` | -O3, -march=native |
 
-- Test: `ctest --test-dir cmake-build-{debug,release} --output-on-failure`
+- Test: `ctest --test-dir cmake-build-{debug,release,asan} --output-on-failure`
 - Format: `cmake --build cmake-build-debug --target format`
 - AVX2 CPUs: Intel Haswell 2013+, AMD Excavator 2015+
+
+### AddressSanitizer (ASAN)
+ASAN detects memory errors at runtime (buffer overflows, use-after-free, memory leaks).
+
+**Use when**:
+- Debugging crashes or unexpected behavior
+- Testing SIMD code for out-of-bounds access
+- Validating array boundary checks
+- Finding memory leaks
+
+**Performance**: ~2x slowdown, ~3x memory usage (debug builds only)
 
 ## ordered_array<Key, Value, Length, SearchMode, MoveMode>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,30 @@ else()
     endif()
 endif()
 
+# Option to enable AddressSanitizer (ASAN) for memory error detection
+# Useful for debugging memory issues like buffer overflows, use-after-free, etc.
+option(ENABLE_ASAN "Enable AddressSanitizer for memory error detection" OFF)
+
+if(ENABLE_ASAN)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(STATUS "Building with AddressSanitizer (ASAN) enabled")
+        add_compile_options(-fsanitize=address)
+        add_compile_options(-fno-omit-frame-pointer)
+        add_compile_options(-g)
+        add_link_options(-fsanitize=address)
+
+        # Disable optimizations that interfere with ASAN
+        add_compile_options(-O1)
+        add_compile_options(-fno-optimize-sibling-calls)
+    elseif(MSVC)
+        message(STATUS "Building with AddressSanitizer (ASAN) enabled (MSVC)")
+        add_compile_options(/fsanitize=address)
+        add_compile_options(/Zi)
+    else()
+        message(WARNING "AddressSanitizer not supported for this compiler")
+    endif()
+endif()
+
 # Set aggressive optimization flags for Release builds only
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -60,6 +84,10 @@ add_subdirectory(third_party/catch2)
 # Add Google Benchmark
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable benchmark tests" FORCE)
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Disable gtest tests" FORCE)
+# Disable -Werror in Google Benchmark when ASAN is enabled to avoid false positives
+if(ENABLE_ASAN)
+    set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "Disable -Werror for ASAN builds" FORCE)
+endif()
 add_subdirectory(third_party/benchmark)
 
 # Enable testing


### PR DESCRIPTION
## Summary
Adds AddressSanitizer (ASAN) build configuration for detecting memory errors during development and testing.

## Changes

### CMakeLists.txt
Added `ENABLE_ASAN` option (default: OFF) that configures:

**Compile/Link Flags**:
- `-fsanitize=address` - Enable AddressSanitizer
- `-fno-omit-frame-pointer` - Better stack traces
- `-g` - Debug symbols for error reports
- `-O1` - Minimal optimization (better error detection than -O0)
- `-fno-optimize-sibling-calls` - Prevents optimization that hides call stacks

**Google Benchmark Integration**:
- Disables `-Werror` when ASAN is enabled
- Avoids false positive warnings from GCC 14 standard library with ASAN + -O1
- Allows clean build while still catching real issues

### CLAUDE.md
Added Debug+ASAN build type to documentation:

**Build Command**:
```bash
cmake -S . -B cmake-build-asan -DENABLE_ASAN=ON
cmake --build cmake-build-asan --parallel
ctest --test-dir cmake-build-asan --output-on-failure
```

**Documentation includes**:
- When to use ASAN (debugging crashes, testing SIMD bounds, finding memory leaks)
- Performance characteristics (~2x slowdown, ~3x memory usage)
- Integration into test command examples

## Testing

Successfully built and tested with ASAN enabled:
```bash
cmake -S . -B cmake-build-asan -DENABLE_ASAN=ON
cmake --build cmake-build-asan --parallel
ctest --test-dir cmake-build-asan --output-on-failure
```

**Results**: All 2 tests pass (sample_test, test_ordered_array)

## Why This Matters

ASAN is essential for:
1. **Catching memory bugs early** - Buffer overflows, use-after-free, memory leaks
2. **SIMD code validation** - Easy to have off-by-one errors in AVX2 implementations
3. **Array boundary checks** - Fixed-size arrays need careful bounds management
4. **CI/CD integration** - Can be run automatically on commits

## Design Decisions

**Why -O1 instead of -O0?**
- ASAN works better with minimal optimization
- -O0 can hide some bugs that appear at higher optimization levels
- Still fast enough for testing

**Why disable -Werror in Benchmark?**
- GCC 14 produces false positive maybe-uninitialized warnings in std::regex with ASAN + -O1
- These are compiler/stdlib implementation details, not our code issues
- Warnings still visible, just not fatal

**Why separate build directory?**
- Avoids contaminating debug/release builds
- Clear separation of sanitized vs unsanitized builds
- Can maintain both simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)
