### PR TITLE
Remove redundant leftmost_leaf_ check from insert hot path

### DIFF
--- a/src/btree.ipp
+++ b/src/btree.ipp
@@ -318,12 +318,6 @@ btree<Key, Value, LeafNodeSize, InternalNodeSize, SearchModeT,
     if (leaf_it == leaf->data.begin() && leaf->parent != nullptr) {
       update_parent_key_recursive(leaf, key);
     }
-
-    // Update leftmost_leaf_ if we inserted at the beginning of the leftmost leaf
-    // Avoids key comparison by checking leaf position in linked list
-    if (leaf_it == leaf->data.begin() && leaf->prev_leaf == nullptr) {
-      leftmost_leaf_ = leaf;
-    }
   }
 
   return {iterator(leaf, leaf_it), inserted};


### PR DESCRIPTION
## Summary
Removes the redundant `leftmost_leaf_` update check from the main insert path in `btree.ipp` (lines 322-326).

## Analysis
The check `if (leaf_it == leaf->data.begin() && leaf->prev_leaf == nullptr)` is redundant because:

1. **Logical redundancy**: If `leaf->prev_leaf == nullptr`, the leaf is already the leftmost leaf in the tree, so `leftmost_leaf_` should already point to it.

2. **Proper maintenance**: `leftmost_leaf_` is correctly maintained by:
   - Initial root creation (`btree.ipp:287`)
   - Split logic (`btree.ipp:672-674`)
   - Empty node deletion in merge operations (`btree.ipp:1175-1176`, `1349-1350`)

3. **Merge behavior**: Merge operations always keep the LEFT node, so `leftmost_leaf_` never points to a node that gets deleted (except empty nodes, which have special handling).

## Benefits
- ✅ Removes unnecessary branch from insert hot path
- ✅ Eliminates redundant check executed on every insert at the beginning of leftmost leaf
- ✅ No functional change - all tests pass

## Testing
- ✅ All 6343 btree test assertions pass (54 test cases)
- ✅ No behavioral changes expected or observed

## Related Discussion
This optimization was identified during code review of the btree insert path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)