### PR TITLE
Add SIMD support for 8-bit and 16-bit primitive integer types

### DIFF
--- a/src/ordered_array.hpp
+++ b/src/ordered_array.hpp
@@ -41,12 +41,22 @@ concept Comparable = requires(T a, T b) {
 // Concept for primitive types that have well-defined SIMD comparison semantics
 template <typename T>
 concept SimdPrimitive =
-    // Fixed-size integer types (preferred)
+    // 8-bit integer types
+    std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> ||
+    // 16-bit integer types
+    std::is_same_v<T, int16_t> || std::is_same_v<T, uint16_t> ||
+    // 32-bit integer types
     std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
+    // 64-bit integer types
     std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> ||
     // Floating point types
     std::is_same_v<T, float> || std::is_same_v<T, double> ||
-    // Common aliases that map to fixed-size types
+    // Common aliases that may map to standard types
+    (std::is_same_v<T, char> && sizeof(char) == 1) ||
+    (std::is_same_v<T, signed char> && sizeof(signed char) == 1) ||
+    (std::is_same_v<T, unsigned char> && sizeof(unsigned char) == 1) ||
+    (std::is_same_v<T, short> && sizeof(short) == 2) ||
+    (std::is_same_v<T, unsigned short> && sizeof(unsigned short) == 2) ||
     (std::is_same_v<T, int> && sizeof(int) == 4) ||
     (std::is_same_v<T, unsigned int> && sizeof(unsigned int) == 4) ||
     (std::is_same_v<T, long> && sizeof(long) == 8) ||
@@ -400,6 +410,22 @@ class ordered_array {
 
  private:
 #ifdef __AVX2__
+  /**
+   * SIMD-accelerated linear search for 8-bit keys (int8_t, uint8_t)
+   * Compares 32 keys at a time using AVX2
+   */
+  template <typename K>
+    requires(sizeof(K) == 1)
+  auto simd_lower_bound_1byte(const K& key) const;
+
+  /**
+   * SIMD-accelerated linear search for 16-bit keys (int16_t, uint16_t)
+   * Compares 16 keys at a time using AVX2
+   */
+  template <typename K>
+    requires(sizeof(K) == 2)
+  auto simd_lower_bound_2byte(const K& key) const;
+
   /**
    * SIMD-accelerated linear search for 32-bit keys (int32_t, uint32_t, float)
    * Compares 8 keys at a time using AVX2


### PR DESCRIPTION
## Summary

Extends `ordered_array` SIMD search capabilities to support all remaining primitive integer types:
- **8-bit types**: `int8_t`, `uint8_t`, `char`, `signed char`, `unsigned char`
- **16-bit types**: `int16_t`, `uint16_t`, `short`, `unsigned short`

This completes SIMD support for all primitive integer types from 8-bit to 64-bit.

## Implementation Details

### 8-bit SIMD Search (`simd_lower_bound_1byte`)
- **AVX2 path**: Processes 32 elements per iteration using `_mm256_cmpgt_epi8`
- **SSE path**: Processes 16 elements per iteration using `_mm_cmpgt_epi8`
- **Scalar fallback**: Handles remaining 0-15 elements
- **Unsigned handling**: XORs keys with `0x80` to convert unsigned comparison to signed comparison space

### 16-bit SIMD Search (`simd_lower_bound_2byte`)
- **AVX2 path**: Processes 16 elements per iteration using `_mm256_cmpgt_epi16`
- **SSE path**: Processes 8 elements per iteration using `_mm_cmpgt_epi16`
- **64-bit SIMD path**: Processes 4 elements per iteration using `_mm_load_sd`
- **Scalar fallback**: Handles remaining 0-3 elements
- **Unsigned handling**: XORs keys with `0x8000` to convert unsigned comparison to signed comparison space
- **Bitmask offset**: Divides by 2 since each 16-bit element contributes 2 bits to the mask

### Key Algorithm: Unsigned Comparison Trick

AVX2 only provides signed comparison intrinsics (`_mm256_cmpgt_epi8`, `_mm256_cmpgt_epi16`). To handle unsigned types correctly:

1. XOR both search key and array keys with the sign bit before comparison
2. This maps the unsigned range to the signed range while preserving ordering:
   - **8-bit**: `[0, 255]` → `[-128, 127]`  
   - **16-bit**: `[0, 65535]` → `[-32768, 32767]`

Example for `uint8_t`:
```cpp
// Without XOR: comparing 200 and 50 as signed bytes would give wrong result
// With XOR:    (200 ^ 0x80) = 72, (50 ^ 0x80) = 178 (in signed space)
//              Correctly identifies 50 < 200 in unsigned space
```

## Changes

### src/ordered_array.hpp
- Extended `SimdPrimitive` concept to include 8-bit and 16-bit types with size checks
- Added `simd_lower_bound_1byte` and `simd_lower_bound_2byte` method declarations

### src/ordered_array.ipp
- Implemented `simd_lower_bound_1byte` with AVX2 → SSE → scalar fallback
- Implemented `simd_lower_bound_2byte` with AVX2 → SSE → 64-bit SIMD → scalar fallback
- Updated `lower_bound_key` to dispatch based on `sizeof(Key)` (1, 2, 4, or 8 bytes)

### src/tests/test_ordered_array.cpp
Added comprehensive test coverage with 6 new test cases:
- `int8_t` tests: basic operations, edge cases (INT8_MIN/MAX), 40-element array
- `uint8_t` tests: basic operations, high values (>127) to verify sign bit handling
- `int16_t` tests: basic operations, edge cases (INT16_MIN/MAX), 20-element array
- `uint16_t` tests: basic operations, high values (>32767) to verify sign bit handling
- `unsigned char` tests: ASCII character operations
- `unsigned short` tests: basic operations

Each test case runs with both `BinarySearchMode` and `SIMDSearchMode` for validation.

## Testing

All tests pass:
```
===============================================================================
All tests passed (512 assertions in 16 test cases)
===============================================================================
```

Test coverage includes:
- ✅ Basic insert/find operations for all new types
- ✅ Edge cases (INT8_MIN/MAX, INT16_MIN/MAX, zero, sign boundaries)
- ✅ High unsigned values (>127 for 8-bit, >32767 for 16-bit) that have sign bit set
- ✅ Large arrays (32+ elements for 8-bit, 16+ elements for 16-bit) to exercise full AVX2 paths
- ✅ Correct lexicographic ordering
- ✅ Type aliases (char, unsigned char, short, unsigned short)

## Performance Expectations

Based on existing SIMD performance data from CLAUDE.md:

**Expected gains for read-heavy workloads (size 32-64)**:
- 8-bit types: 45-59% faster than linear search (processes 4× more keys per AVX2 iteration than int32_t)
- 16-bit types: 45-59% faster than linear search (processes 2× more keys per AVX2 iteration than int32_t)

**Best use cases**:
- Read-heavy workloads with frequent `find()` operations
- Arrays with >32 elements
- Negative lookups (searching for non-existent keys)

**Not recommended for**:
- Write-heavy workloads (use `Linear` mode)
- Small arrays (<32 elements, use `Linear` mode)

## Related Work

This PR completes the SIMD primitive type support started in earlier PRs:
- Existing: 32-bit (int32_t, uint32_t, float) and 64-bit (int64_t, uint64_t, double)
- New: 8-bit and 16-bit integer types

The implementation follows the same proven pattern as existing SIMD code, ensuring consistency across all primitive types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)