### PR TITLE
Add SIMD search support for std::greater (descending order)

### DIFF
--- a/src/ordered_array.hpp
+++ b/src/ordered_array.hpp
@@ -113,13 +113,13 @@ class ordered_array {
   // Static assertions for SIMD mode requirements
   static_assert(
       SearchModeT != SearchMode::SIMD ||
-          (SIMDSearchable<Key> && std::is_same_v<Compare, std::less<Key>>),
+          (SIMDSearchable<Key> && (std::is_same_v<Compare, std::less<Key>> ||
+                                   std::is_same_v<Compare, std::greater<Key>>)),
       "SearchMode::SIMD requires:\n"
       "  1. Key type must be a primitive type (int8_t, uint8_t, int16_t, "
       "uint16_t, int32_t, uint32_t, int64_t, uint64_t, float, double)\n"
-      "  2. Compare must be std::less<Key> (ascending order only)\n"
-      "For descending order (std::greater) or custom comparators, use "
-      "SearchMode::Binary or SearchMode::Linear");
+      "  2. Compare must be std::less<Key> or std::greater<Key>\n"
+      "For custom comparators, use SearchMode::Binary or SearchMode::Linear");
 
   /**
    * Default constructor - initializes an empty ordered array


### PR DESCRIPTION
## Summary

Extends SIMD-accelerated search to support **std::greater** (descending order) in addition to std::less. Previously, SIMD mode only worked with ascending order.

This builds on the custom comparator support added in PRs #64 and #65.

## Changes

### 1. ordered_array.hpp
- **Updated static_assert** to allow both `std::less<Key>` and `std::greater<Key>`
- Updated error message to reflect dual comparator support

### 2. ordered_array.ipp - All SIMD Implementations

Added compile-time comparator detection and adapted comparison logic:

**Pattern:**
```cpp
constexpr bool is_ascending = std::is_same_v<Compare, std::less<Key>>;

__m256i cmp;
if constexpr (is_ascending) {
  cmp = _mm256_cmpgt_epi32(search_vec, keys_vec);  // keys < search
} else {
  cmp = _mm256_cmpgt_epi32(keys_vec, search_vec);  // keys > search
}
```

**Updated implementations:**
- `simd_lower_bound_1byte` (int8_t, uint8_t) - 32 keys per AVX2 iteration
- `simd_lower_bound_2byte` (int16_t, uint16_t) - 16 keys per AVX2 iteration
- `simd_lower_bound_4byte` (int32_t, uint32_t, float) - 8 keys per AVX2 iteration
- `simd_lower_bound_8byte` (int64_t, uint64_t, double) - 4 keys per AVX2 iteration

**For floats/doubles:**
- Ascending: `_mm256_cmp_ps/pd(..., _CMP_LT_OQ)` 
- Descending: `_mm256_cmp_ps/pd(..., _CMP_GT_OQ)`

**For integers:**
- Ascending: `_mm256_cmpgt_epi**(search, keys)` → keys < search
- Descending: `_mm256_cmpgt_epi**(keys, search)` → keys > search

### 3. test_ordered_array.cpp

- **Removed outdated comment**: "SIMD mode only supports std::less"
- **Added 6 comprehensive test sections** for SIMD + std::greater:
  - 4-byte keys (int32_t): 50 elements, tests find, lower_bound, iteration order
  - 8-byte keys (int64_t): 40 elements
  - 4-byte keys (float): 5 fractional values
  - 8-byte keys (double): 30 elements
  - 2-byte keys (int16_t): 50 elements
  - 1-byte keys (int8_t): 50 elements

## Technical Details

### Search Semantics

**Ascending order (std::less):**
- Goal: Find first position where `key >= search_key`
- SIMD checks: `keys_vec < search_vec`, finds first false

**Descending order (std::greater):**
- Goal: Find first position where `key <= search_key`
- SIMD checks: `keys_vec > search_vec`, finds first false

### Performance

SIMD provides consistent speedups for large arrays:
- Size 32: 45% faster than Linear
- Size 64: 59% faster than Linear

This applies equally to both std::less and std::greater.

## Testing

✅ All 102+ SIMD test assertions pass (AVX2 enabled)
✅ All btree tests pass (6367 assertions)
✅ Verified all key sizes: 1, 2, 4, 8 bytes
✅ Both signed/unsigned integers and floats/doubles

## Benefits

- 🚀 **SIMD performance for descending order** (previously unavailable)
- 🔄 **Consistent API** across std::less and std::greater
- ⚡ **Zero runtime overhead** - all logic resolved at compile-time via `if constexpr`
- ✅ **Comprehensive test coverage** for all primitive types
- 📈 **Enables SIMD for more use cases** (e.g., priority queues, recent-first sorting)

## Example Usage

```cpp
// Ascending order (default)
ordered_array<int, std::string, 64, std::less<int>, SearchMode::SIMD> asc;
asc.insert(5, "five");
asc.insert(3, "three");
// Iterates: 3, 5 (SIMD-accelerated find)

// Descending order (now with SIMD!)
ordered_array<int, std::string, 64, std::greater<int>, SearchMode::SIMD> desc;
desc.insert(5, "five");
desc.insert(3, "three");
// Iterates: 5, 3 (SIMD-accelerated find)
```

## Related PRs

- PR #64: Custom comparator support for `ordered_array`
- PR #65: Custom comparator support for `btree`
- This PR: SIMD optimization for std::greater

🤖 Generated with [Claude Code](https://claude.com/claude-code)