### PR TITLE
Replace external free list with intrusive free list

### DIFF
--- a/src/tests/test_hugepage_allocator.cpp
+++ b/src/tests/test_hugepage_allocator.cpp
@@ -6,16 +6,16 @@
 using namespace fast_containers;
 
 TEST_CASE("HugePageAllocator - basic allocation", "[hugepage_allocator]") {
-  HugePageAllocator<int> alloc(1024 * 1024);  // 1MB pool
+  HugePageAllocator<int64_t> alloc(1024 * 1024);  // 1MB pool
 
   SECTION("Allocate and deallocate single elements") {
-    int* p1 = alloc.allocate(1);
+    int64_t* p1 = alloc.allocate(1);
     REQUIRE(p1 != nullptr);
     *p1 = 42;
     REQUIRE(*p1 == 42);
     alloc.deallocate(p1, 1);
 
-    int* p2 = alloc.allocate(1);
+    int64_t* p2 = alloc.allocate(1);
     REQUIRE(p2 != nullptr);
     *p2 = 100;
     REQUIRE(*p2 == 100);
@@ -30,7 +30,7 @@ TEST_CASE("HugePageAllocator - basic allocation", "[hugepage_allocator]") {
     size_t initial = alloc.bytes_remaining();
     REQUIRE(initial > 0);
 
-    int* p = alloc.allocate(1);
+    int64_t* p = alloc.allocate(1);
     size_t after = alloc.bytes_remaining();
     REQUIRE(after < initial);
 
@@ -39,14 +39,14 @@ TEST_CASE("HugePageAllocator - basic allocation", "[hugepage_allocator]") {
 }
 
 TEST_CASE("HugePageAllocator - rebind", "[hugepage_allocator]") {
-  using IntAlloc = HugePageAllocator<int>;
-  using DoubleAlloc = typename IntAlloc::rebind<double>::other;
+  using Int64Alloc = HugePageAllocator<int64_t>;
+  using DoubleAlloc = typename Int64Alloc::rebind<double>::other;
 
-  IntAlloc int_alloc(1024 * 1024);
-  DoubleAlloc double_alloc(int_alloc);
+  Int64Alloc int64_alloc(1024 * 1024);
+  DoubleAlloc double_alloc(int64_alloc);
 
   SECTION("Rebind creates separate pool") {
-    int* ip = int_alloc.allocate(1);
+    int64_t* ip = int64_alloc.allocate(1);
     double* dp = double_alloc.allocate(1);
 
     REQUIRE(ip != nullptr);
@@ -58,7 +58,7 @@ TEST_CASE("HugePageAllocator - rebind", "[hugepage_allocator]") {
     REQUIRE(*ip == 42);
     REQUIRE(*dp == 3.14);
 
-    int_alloc.deallocate(ip, 1);
+    int64_alloc.deallocate(ip, 1);
     double_alloc.deallocate(dp, 1);
   }
 }
@@ -66,10 +66,10 @@ TEST_CASE("HugePageAllocator - rebind", "[hugepage_allocator]") {
 TEST_CASE("HugePageAllocator - fallback to regular pages",
           "[hugepage_allocator]") {
   // Force fallback by requesting hugepages but allowing fallback
-  HugePageAllocator<int> alloc(1024 * 1024, true);
+  HugePageAllocator<int64_t> alloc(1024 * 1024, true);
 
   SECTION("Allocator works regardless of hugepage availability") {
-    int* p = alloc.allocate(1);
+    int64_t* p = alloc.allocate(1);
     REQUIRE(p != nullptr);
     *p = 42;
     REQUIRE(*p == 42);


### PR DESCRIPTION
Implements the optimization proposed in issue #70.

## Summary

Replaces the external `std::vector<void*>` free list with an intrusive linked list that stores the next pointer directly in freed memory blocks.

## Implementation

**Before:**
```cpp
std::vector<void*> free_list_;  // External storage for free blocks

// Deallocate
pool_->free_list_.push_back(p);

// Allocate
void* ptr = pool_->free_list_.back();
pool_->free_list_.pop_back();
```

**After:**
```cpp
void* free_list_head_;  // Single pointer to head of intrusive list

// Deallocate - store next pointer in freed block
*reinterpret_cast<void**>(p) = pool_->free_list_head_;
pool_->free_list_head_ = p;

// Allocate - read next pointer from block
void* ptr = pool_->free_list_head_;
pool_->free_list_head_ = *reinterpret_cast<void**>(ptr);
```

## Benefits

1. ✅ **No vector reallocation** - eliminates potential allocations when free list grows
2. ✅ **Better cache locality** - reuses memory that's already in cache or will be accessed soon
3. ✅ **Less memory overhead** - single pointer (8 bytes) vs vector (24+ bytes + heap allocation)
4. ✅ **Simpler code** - no vector to manage

## Safety

- Added `static_assert(sizeof(T) >= sizeof(void*))` to ensure type is large enough for intrusive list
- For btree use case: LeafNode and InternalNode are hundreds of bytes (>> 8 bytes) ✅

## Changes

- Updated `Pool::free_list_` from `std::vector<void*>` to `void* free_list_head_`
- Updated `allocate()` to pop from intrusive list
- Updated `deallocate()` to push to intrusive list
- Updated tests to use `int64_t` instead of `int` (meets sizeof requirement)
- Updated documentation to reflect intrusive free list

## Testing

All tests pass: 13,554 assertions in 7 test cases ✅

## Technique

This is a classic technique used in production allocators like jemalloc and tcmalloc. The freed memory is repurposed to store metadata (next pointer) until it's allocated again.

Closes #70