### PR TITLE
Add try_emplace() for efficient in-place value construction

### DIFF
--- a/src/btree.hpp
+++ b/src/btree.hpp
@@ -656,6 +656,24 @@ class btree {
   iterator emplace_hint(const_iterator hint, Args&&... args);
 
   /**
+   * Inserts a new element if the key does not exist.
+   * Constructs the value in-place using the provided arguments.
+   * If the key already exists, does nothing (does not construct the value).
+   *
+   * This is more efficient than emplace() when the key might already exist,
+   * as it avoids constructing the value unnecessarily.
+   *
+   * @param key The key to insert
+   * @param args Arguments to forward to the Value constructor
+   * @return Pair of iterator to inserted/existing element and bool indicating
+   * success
+   *
+   * Complexity: O(log n)
+   */
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args);
+
+  /**
    * Accesses or inserts an element with the specified key.
    * If the key exists, returns a reference to the associated value.
    * If the key does not exist, inserts a new element with default-constructed

--- a/src/btree.ipp
+++ b/src/btree.ipp
@@ -412,6 +412,53 @@ btree<Key, Value, LeafNodeSize, InternalNodeSize, Compare, SearchModeT,
   return emplace(std::forward<Args>(args)...).first;
 }
 
+// try_emplace
+template <typename Key, typename Value, std::size_t LeafNodeSize,
+          std::size_t InternalNodeSize, typename Compare, SearchMode SearchModeT,
+          MoveMode MoveModeT, typename Allocator>
+  requires ComparatorCompatible<Key, Compare>
+template <typename... Args>
+std::pair<typename btree<Key, Value, LeafNodeSize, InternalNodeSize, Compare,
+                         SearchModeT, MoveModeT, Allocator>::iterator,
+          bool>
+btree<Key, Value, LeafNodeSize, InternalNodeSize, Compare, SearchModeT,
+      MoveModeT, Allocator>::try_emplace(const Key& key, Args&&... args) {
+  // Find the appropriate leaf for the key
+  LeafNode* leaf = find_leaf_for_key(key);
+
+  // Use lower_bound to find position - single search for both existence check
+  // and insertion point
+  auto pos = leaf->data.lower_bound(key);
+
+  // CRITICAL: Check if key already exists BEFORE constructing the value
+  // This is the key advantage of try_emplace over emplace
+  if (pos != leaf->data.end() && pos->first == key) {
+    return {iterator(leaf, pos), false};
+  }
+
+  // If leaf is full, we need to split
+  // In this case, we have to construct the value to pass to split_leaf
+  // This is the rare case, so acceptable to construct temp
+  if (leaf->data.size() >= LeafNodeSize) {
+    Value temp_value(std::forward<Args>(args)...);
+    return split_leaf(leaf, key, std::move(temp_value));
+  }
+
+  // Leaf has space - use try_emplace to construct value in-place
+  // This is the common case where we get the performance benefit
+  auto [leaf_it, inserted] = leaf->data.try_emplace(key, std::forward<Args>(args)...);
+  if (inserted) {
+    size_++;
+
+    // If we inserted at the beginning and leaf has a parent, update parent key
+    if (leaf_it == leaf->data.begin() && leaf->parent != nullptr) {
+      update_parent_key_recursive(leaf, key);
+    }
+  }
+
+  return {iterator(leaf, leaf_it), inserted};
+}
+
 // operator[]
 template <typename Key, typename Value, std::size_t LeafNodeSize,
           std::size_t InternalNodeSize, typename Compare, SearchMode SearchModeT,

--- a/src/ordered_array.hpp
+++ b/src/ordered_array.hpp
@@ -190,6 +190,20 @@ class ordered_array {
                                         const Value& value);
 
   /**
+   * Inserts a new element if the key does not exist.
+   * Constructs the value in-place using the provided arguments.
+   * If the key already exists, does nothing (does not construct the value).
+   *
+   * @param key The key to insert
+   * @param args Arguments to forward to the Value constructor
+   * @return Pair of iterator to inserted/existing element and bool indicating
+   * success
+   * @throws std::runtime_error if the array is full
+   */
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args);
+
+  /**
    * Find an element by key.
    *
    * @param key The key to search for


### PR DESCRIPTION
## Summary

Implements `try_emplace()` for both `ordered_array` and `btree` to enable efficient in-place value construction. Unlike `emplace()`, which always constructs a value even when the key already exists, `try_emplace()` only constructs the value when the key is not found.

This is a significant performance win for scenarios where duplicate key insertions are common, as it avoids unnecessary value construction.

## Implementation Details

### ordered_array
- Added `try_emplace()` template method with variadic arguments
- Uses `std::construct_at(&values_[idx], std::forward<Args>(args)...)` for true in-place construction
- Checks key existence **before** value construction (the key optimization)
- Throws `std::runtime_error` if array is full (consistent with existing behavior)

### btree
- Added `try_emplace()` template method that delegates to `ordered_array::try_emplace()`
- Handles two cases:
  - **Common case** (leaf has space): Delegates to `ordered_array::try_emplace()` for in-place construction
  - **Rare case** (leaf full, needs split): Constructs temporary value then moves (acceptable overhead for rare case)
- Properly updates parent keys when inserting at beginning of leaf

### Tests
- Comprehensive test suite with **2274 assertions** across **11 test sections**
- Tested across all 3 search modes: Binary, Linear, SIMD
- Created `ConstructionTracker` helper class to verify construction behavior:
  - Tracks default, value, copy, and move constructions
  - Proves that `try_emplace()` avoids value construction when key exists
  - Shows the performance advantage over `emplace()`
- Test coverage includes:
  - Basic insertion and duplicate detection
  - Multiple constructor arguments forwarding
  - Zero-argument (default) construction
  - String values with in-place construction
  - Large trees with splits (100+ elements)
  - Direct comparison with `emplace()` behavior
  - Complex value types with multiple members

## Performance Benefits

When key already exists:
- **`emplace()`**: Constructs value, then discards it ❌
- **`try_emplace()`**: Skips value construction entirely ✅

This is especially beneficial for:
- Expensive-to-construct value types
- Scenarios with frequent duplicate key attempts
- Cache initialization patterns
- Idempotent operations

## API Compatibility

This brings `btree` closer to full `std::map` compatibility. Related to issue #78.

## Test Results

```
All tests passed (2274 assertions in 3 test cases)
```

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)