### PR TITLE
Add insert_or_assign() for insert-or-update semantics

### DIFF
--- a/src/btree.hpp
+++ b/src/btree.hpp
@@ -674,6 +674,23 @@ class btree {
   std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args);
 
   /**
+   * Inserts a new element or assigns to an existing one.
+   * If the key exists, assigns the new value to the existing element.
+   * If the key doesn't exist, inserts a new element with the value.
+   *
+   * This is different from insert() which leaves existing values unchanged.
+   *
+   * @param key The key to insert or assign
+   * @param value The value to insert or assign
+   * @return Pair of iterator to inserted/updated element and bool indicating
+   * insertion (true) vs assignment (false)
+   *
+   * Complexity: O(log n)
+   */
+  template <typename M>
+  std::pair<iterator, bool> insert_or_assign(const Key& key, M&& value);
+
+  /**
    * Accesses or inserts an element with the specified key.
    * If the key exists, returns a reference to the associated value.
    * If the key does not exist, inserts a new element with default-constructed

--- a/src/ordered_array.hpp
+++ b/src/ordered_array.hpp
@@ -204,6 +204,20 @@ class ordered_array {
   std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args);
 
   /**
+   * Inserts a new element or assigns to an existing one.
+   * If the key exists, assigns the new value to the existing element.
+   * If the key doesn't exist, inserts a new element with the value.
+   *
+   * @param key The key to insert or assign
+   * @param value The value to insert or assign
+   * @return Pair of iterator to inserted/updated element and bool indicating
+   * insertion (true) vs assignment (false)
+   * @throws std::runtime_error if the array is full and key doesn't exist
+   */
+  template <typename M>
+  std::pair<iterator, bool> insert_or_assign(const Key& key, M&& value);
+
+  /**
    * Find an element by key.
    *
    * @param key The key to search for


### PR DESCRIPTION
## Summary

Implements `insert_or_assign()` for both `ordered_array` and `btree` to provide insert-or-update semantics. Unlike `insert()` which leaves existing values unchanged, `insert_or_assign()` updates the value when the key already exists.

This is a commonly requested `std::map` feature that's particularly useful for cache updates, configuration management, and other scenarios where you want to either add a new entry or update an existing one.

## Implementation Details

### ordered_array
- Added `insert_or_assign()` template method accepting key and value
- Checks if key exists using `lower_bound_key()`
- If key exists: **assigns** the new value (key difference from `insert()`)
- If key doesn't exist: inserts new element
- Returns `(iterator, bool)` where bool indicates insertion (true) vs assignment (false)

### btree  
- Added `insert_or_assign()` template method that delegates to `ordered_array::insert_or_assign()`
- Handles two cases:
  - **Key exists**: Directly assigns to the existing element, returns false
  - **Key doesn't exist**: 
    - If leaf has space: delegates to `ordered_array::insert_or_assign()`
    - If leaf full: calls `split_leaf()` with the new value
- Properly updates parent keys when inserting at beginning of leaf

### Tests
- Comprehensive test suite with **2412 assertions** across **10 test sections**
- Tested across all 3 search modes: Binary, Linear, SIMD
- Test coverage includes:
  - Basic insert and assign operations
  - Multiple elements in sequence
  - Update all values in tree (verify assignment works)
  - Mixed insert and assign operations
  - Large trees with splits (100+ elements)
  - Direct comparison with `insert()` behavior
  - String keys and values
  - Return value consistency

## Key Difference from insert()

```cpp
// insert() - leaves existing values unchanged
tree.insert(5, 50);
auto [it, inserted] = tree.insert(5, 999);
// inserted = false, it->second = 50 (original value unchanged)

// insert_or_assign() - updates existing values
tree.insert(5, 50);  
auto [it, inserted] = tree.insert_or_assign(5, 999);
// inserted = false, it->second = 999 (value was updated!)
```

## Use Cases

- **Cache updates**: Replace stale cached values
- **Configuration management**: Set or update config values
- **Dictionary operations**: Add or modify dictionary entries
- **Idempotent state updates**: Ensure value is set regardless of prior state
- **Data synchronization**: Update local state from remote changes

## API Compatibility

This brings `btree` closer to full `std::map` compatibility. Related to issue #78.

## Test Results

```
All tests passed (2412 assertions in 3 test cases)
```

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)